### PR TITLE
disable https certificate checks in wget

### DIFF
--- a/download_app.sh
+++ b/download_app.sh
@@ -29,7 +29,7 @@ function download_package()
 {
     blue_echo "Downloading.... $APP"
     command_runner \
-        wget -c  $@ -P $BASE/src -O ${APP}.${EXT} log.download.${APP}
+        wget --no-check-certificate -c  $@ -P $BASE/src -O ${APP}.${EXT} log.download.${APP}
     return 0
 }
 


### PR DESCRIPTION
It was failing in VAPOR app:

```
https://docs.vapor.ucar.edu/sites/default/files/vapor-2.3.0-Linux_x86_64.tar.gz
```
