### PR TITLE
libpng URL fixed

### DIFF
--- a/apps/LIBPNG.env
+++ b/apps/LIBPNG.env
@@ -4,5 +4,5 @@ VERSION=1.5.19
 EXT=tar.gz
 DEP=(ZLIB)
 DIR=${APP}
-URL=http://sourceforge.net/projects/libpng/files/libpng15/1.5.19/${APP}.${EXT}
+URL=http://sourceforge.net/projects/libpng/files/libpng15/older-releases/1.5.19/${APP}.${EXT}
 LIBPNG_ROOT=$WRF_BASE/$dep_root


### PR DESCRIPTION
Correct the url from:
http://sourceforge.net/projects/libpng/files/libpng15/1.5.19/
to:
http://sourceforge.net/projects/libpng/files/libpng15/older-releases/1.5.19/